### PR TITLE
fix: use CUDA in Docker web-gui when no runtime variant is selected

### DIFF
--- a/src/utils/runtime_manager.py
+++ b/src/utils/runtime_manager.py
@@ -175,10 +175,16 @@ def set_selected_variant(variant: str) -> None:
 
 
 def torch_device_for(variant: str | None) -> str:
-    """Строка устройства torch для выбранного варианта."""
+    """Строка устройства torch для выбранного варианта.
+
+    Если вариант не выбран (None) — возвращает 'auto', чтобы вызывающая
+    сторона сама определила устройство по возможностям torch. Это важно
+    для Docker-сборки, где torch с CUDA уже предустановлен системно
+    и выбор варианта через диалог не выполняется.
+    """
     if variant and variant in VARIANTS:
         return VARIANTS[variant]["torch_device"]
-    return "cpu"
+    return "auto"
 
 
 # ── Проверка установленных вариантов ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `torch_device_for(None)` returned `"cpu"`, which forced `_select_device()` in `src/core/model_loader.py` to pick **CPU** even when `torch.cuda.is_available()` was `True`.
- In the Docker image (`Dockerfile`) torch with CUDA is preinstalled system-wide, and the desktop device-selection dialog never runs, so `runtime.json` is never created and `get_selected_variant()` returns `None`. As a result the web GUI silently ran on CPU despite a visible GPU (e.g. RTX 5080, `torch.cuda.is_available() == True`, `nvidia-smi` visible inside the container).
- Return `"auto"` for `None` so `_select_device()` falls through to its existing auto-detection block and picks `cuda` when available. Desktop GUI is unaffected: the variant is always set via `ensure_device_interactive()` (`src/gui/device_dialog.py`) before model loading, so `torch_device_for` returns the variant's `torch_device` (`"cpu"`/`"cuda"`), not `"auto"`.

## Verification

Before fix (docker compose up):
```
Variant: None
Устройство вычисления: CPU
Модель загружена. Устройство: CPU
```

After fix:
```
Устройство вычисления: CUDA
Модель загружена. Устройство: CUDA
```

`torch.cuda.is_available()` → `True`, `torch.cuda.get_device_name(0)` → `NVIDIA GeForce RTX 5080` inside the container.

## Test plan

- [x] `docker compose up --build` — web GUI now starts on CUDA
- [x] `torch.cuda.is_available()` confirmed inside container
- [ ] Desktop GUI regression: launch app, confirm device dialog still picks the chosen variant (no behavior change expected — variant is set before model load)

Made with [Cursor](https://cursor.com)