### PR TITLE
feat: intelligent adaptive audio preprocessing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,13 @@ AUDIO_SAMPLE_RATE=16000
 # Количество каналов (1 = моно, 2 = стерео). Рекомендуется: 1
 AUDIO_CHANNELS=1
 
+# Интеллектуальная подготовка: off | auto | light | denoise
+AUDIO_PREPROCESSING_MODE=auto
+
+# Опциональный writable+executable cache для self-contained DeepFilterNet binary.
+# Обычно определяется автоматически. Нужен для hardened/noexec окружений.
+# GIGAAM_DEEPFILTER_DIR=/path/to/executable/cache
+
 # ==================== Model Settings ====================
 # Настройки модели транскрибации
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [Быстрый старт](#быстрый-старт)
 - [Интерфейсы](#интерфейсы)
 - [Конфигурация](#конфигурация)
+- [Интеллектуальная подготовка аудио](#интеллектуальная-подготовка-аудио)
 - [ASR backend](#asr-backend)
 - [Структура](#структура)
 - [Скриншоты](#скриншоты)
@@ -28,6 +29,7 @@
 - Пакетная обработка файлов и папок, рекурсивный поиск, drag & drop, загрузка через `yt-dlp`.
 - Экспорт: `txt`, `txt_timecodes`, `txt_diarize`, `txt_diarize_timecodes`, `md`, `srt`, `vtt`.
 - Выбираемая диаризация: `pyannote` или NVIDIA Streaming Sortformer v2.1.
+- Автоматическая диагностика качества, консервативная очистка и safe fallback без сдвига таймкодов.
 - Ускорение MLX RNN-T на Apple Silicon; CPU, CUDA, Intel XPU и MPS.
 - LLM-постобработка: выжимки, задачи и свои промпты.
 - Провайдеры LLM: OpenAI-compatible API, Claude Code, Codex, OpenCode, Pi и произвольный CLI.
@@ -111,6 +113,43 @@ python -m pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --index
 python -m pip install -r requirements.txt
 ```
 
+## Интеллектуальная подготовка аудио
+
+По умолчанию `AUDIO_PREPROCESSING_MODE=auto`. Перед ASR приложение измеряет
+громкость, noise floor, приблизительный SNR, clipping, тишину, DC offset,
+spectral flatness и низкочастотный шум. Детерминированная policy выбирает одно
+из действий:
+
+- pass-through для уже качественной записи;
+- только нормализацию для тихой записи;
+- мягкий FFmpeg high-pass/denoise для умеренного шума;
+- DeepFilterNet для сильного широкополосного шума;
+- отказ от enhancement при клиппинге, почти пустой записи или неуверенном результате.
+
+После обработки кандидат измеряется повторно. Он используется только если
+quality gate подтверждает улучшение без роста клиппинга, потери речи и изменения
+длительности. ASR получает выбранную дорожку, а диаризация — исходный canonical
+WAV: это сохраняет тембр спикеров, границы реплик и таймкоды. Паузы физически не
+удаляются.
+
+DeepFilterNet запускается официальным self-contained Rust binary версии `0.5.6`.
+Он скачивается с GitHub Releases только при первом обнаружении тяжёлого шума,
+проверяется по закреплённому SHA-256 и хранится в runtime cache. Python-пакет
+DeepFilterNet не устанавливается и не конфликтует с NumPy 2. Поддерживаются
+Windows x64, macOS Intel/Apple Silicon и Linux x64/arm64. При недоступной сети,
+неподдерживаемой платформе или любой ошибке транскрибация продолжится с исходной
+дорожкой.
+
+```env
+AUDIO_PREPROCESSING_MODE=auto  # off | auto | light | denoise
+# GIGAAM_DEEPFILTER_DIR=/writable/executable/cache
+```
+
+```bash
+python cli.py --audio-preprocessing auto -f noisy.wav
+python cli.py --audio-preprocessing off -f studio.wav
+```
+
 ## ASR backend
 
 `auto` на macOS Apple Silicon использует [gigaam-mlx](https://github.com/aystream/gigaam-mlx), затем при необходимости переключается на PyTorch. Остальные платформы используют PyTorch.
@@ -152,3 +191,4 @@ GigaAMGUI/
 - [GigaAM-v3 on Hugging Face](https://huggingface.co/ai-sage/GigaAM-v3)
 - [aystream / gigaam-mlx](https://github.com/aystream/gigaam-mlx)
 - [NVIDIA Streaming Sortformer v2.1](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1)
+- [DeepFilterNet](https://github.com/Rikorose/DeepFilterNet) — MIT, optional neural noise suppression

--- a/README_EN.md
+++ b/README_EN.md
@@ -18,6 +18,7 @@ Russian speech-to-text transcription for audio and video powered by **GigaAM-v3*
 - [Quick start](#quick-start)
 - [Interfaces](#interfaces)
 - [Configuration](#configuration)
+- [Intelligent audio preprocessing](#intelligent-audio-preprocessing)
 - [ASR backend](#asr-backend)
 - [Project layout](#project-layout)
 - [Screenshots](#screenshots)
@@ -28,6 +29,7 @@ Russian speech-to-text transcription for audio and video powered by **GigaAM-v3*
 - Batch processing, recursive folder scans, drag & drop, and media downloads through `yt-dlp`.
 - Export to `txt`, `txt_timecodes`, `txt_diarize`, `txt_diarize_timecodes`, `md`, `srt`, and `vtt`.
 - Selectable diarization through `pyannote` or NVIDIA Streaming Sortformer v2.1.
+- Automatic quality diagnostics, conservative cleanup, and timeline-safe fallback.
 - MLX RNN-T on Apple Silicon; CPU, CUDA, Intel XPU, and MPS support.
 - LLM summaries, action items, and custom prompts.
 - OpenAI-compatible API, Claude Code, Codex, OpenCode, Pi, and arbitrary CLI LLM providers.
@@ -112,6 +114,30 @@ python -m pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --index
 python -m pip install -r requirements.txt
 ```
 
+## Intelligent audio preprocessing
+
+`AUDIO_PREPROCESSING_MODE=auto` is the default. The application measures
+loudness, noise floor, estimated SNR, clipping, silence, DC offset, spectral
+flatness, and low-frequency noise. It then selects pass-through, normalization,
+light FFmpeg cleanup, or neural denoising. A second analysis rejects candidates
+that increase clipping, erase speech, fail to improve measurable noise, or alter
+duration. The enhanced track is used only for ASR; diarization keeps the aligned
+canonical track and pauses are never removed.
+
+For severe broadband noise, the official self-contained DeepFilterNet 0.5.6
+binary is downloaded on demand, verified against a pinned SHA-256, and stored in
+the runtime cache. No DeepFilterNet Python dependency is installed. Any download,
+platform, or inference failure falls back to the canonical audio.
+
+```env
+AUDIO_PREPROCESSING_MODE=auto  # off | auto | light | denoise
+# GIGAAM_DEEPFILTER_DIR=/writable/executable/cache
+```
+
+```bash
+python cli.py --audio-preprocessing auto -f noisy.wav
+```
+
 ## ASR backend
 
 On macOS Apple Silicon, `auto` uses [gigaam-mlx](https://github.com/aystream/gigaam-mlx) and falls back to PyTorch when necessary. Other platforms use PyTorch.
@@ -153,3 +179,4 @@ GigaAMGUI/
 - [GigaAM-v3 on Hugging Face](https://huggingface.co/ai-sage/GigaAM-v3)
 - [aystream / gigaam-mlx](https://github.com/aystream/gigaam-mlx)
 - [NVIDIA Streaming Sortformer v2.1](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1)
+- [DeepFilterNet](https://github.com/Rikorose/DeepFilterNet) — MIT, optional neural noise suppression

--- a/api.py
+++ b/api.py
@@ -38,7 +38,7 @@ from starlette.background import BackgroundTask
 warnings.filterwarnings("ignore", category=UserWarning)
 
 # Импорты проекта
-from src.config import HF_TOKEN, SUPPORTED_FORMATS
+from src.config import AUDIO_PREPROCESSING_MODE, HF_TOKEN, SUPPORTED_FORMATS
 from src.core.model_loader import ModelLoader
 from src.services import file_policy, task_store, transcription_service
 from src.services import health as health_service
@@ -538,6 +538,7 @@ async def process_transcription(task_id: str, file_path: Path, filename: str):
                 stage_names = {
                     'preparing': 'Подготовка...',
                     'conversion': 'Конвертация...',
+                    'preprocessing': 'Анализ и подготовка аудио...',
                     'transcription': 'Распознавание речи...',
                     'diarization': 'Диаризация...',
                     'export': 'Экспорт...',
@@ -572,6 +573,7 @@ async def process_transcription(task_id: str, file_path: Path, filename: str):
                     1,
                     filename,  # Передаем оригинальное имя файла
                     output_formats=['txt', 'txt_timecodes'],
+                    audio_preprocessing_mode=AUDIO_PREPROCESSING_MODE,
                 )
             )
 
@@ -607,6 +609,7 @@ async def process_transcription(task_id: str, file_path: Path, filename: str):
                     'transcription_timecoded': transcription_timecoded,
                     'processing_time': result['total_time'],
                     'media_duration': result.get('media_duration', 0),
+                    'audio_preprocessing': result.get('audio_preprocessing'),
                     'message': 'Транскрибация успешно завершена'
                 })
 

--- a/cli.py
+++ b/cli.py
@@ -31,7 +31,7 @@ warnings.filterwarnings("ignore", category=UserWarning)
 
 # Импорты из проекта
 from src.cli_support import interactive as cli_interactive
-from src.config import ASR_BACKEND, OUTPUT_FORMATS
+from src.config import ASR_BACKEND, AUDIO_PREPROCESSING_MODE, OUTPUT_FORMATS
 from src.core.model_loader import ModelLoader
 from src.core.progress import ProgressEvent
 from src.services import transcription_service
@@ -128,6 +128,7 @@ def process_files_with_progress(
     enable_diarization: bool = False,
     num_speakers: int | None = None,
     diarization_backend: str = "pyannote",
+    audio_preprocessing_mode: str = AUDIO_PREPROCESSING_MODE,
 ) -> list[dict]:
     """
     Обрабатывает файлы с отображением прогресса
@@ -173,6 +174,7 @@ def process_files_with_progress(
         stage_names = {
             "preparing": "Подготовка...",
             "conversion": "Конвертация...",
+            "preprocessing": "Анализ и подготовка аудио...",
             "transcription": "Распознавание речи...",
             "diarization": "Диаризация...",
             "export": "Экспорт...",
@@ -244,6 +246,7 @@ def process_files_with_progress(
                 total_files=len(files),
                 enable_diarization=enable_diarization,
                 diarization_backend=diarization_backend,
+                audio_preprocessing_mode=audio_preprocessing_mode,
                 num_speakers=num_speakers,
                 output_formats=output_formats,
             )
@@ -388,7 +391,17 @@ def display_results(results: list[dict]):
     default=None,
     help='Количество спикеров для диаризации (если известно)'
 )
-def main(files, directory, output, interactive, verbose, formats, backend, diarize, diarization_backend, speakers):
+@click.option(
+    '--audio-preprocessing',
+    type=click.Choice(["off", "auto", "light", "denoise"]),
+    default=AUDIO_PREPROCESSING_MODE,
+    show_default=True,
+    help='Интеллектуальная подготовка аудио перед распознаванием',
+)
+def main(
+    files, directory, output, interactive, verbose, formats, backend,
+    diarize, diarization_backend, speakers, audio_preprocessing,
+):
     """
     🎙️ GigaAM v3 Transcriber - CLI
 
@@ -524,6 +537,7 @@ def main(files, directory, output, interactive, verbose, formats, backend, diari
         output_formats=list(formats) if formats else ['txt'],
         enable_diarization=diarize,
         diarization_backend=diarization_backend,
+        audio_preprocessing_mode=audio_preprocessing,
         num_speakers=speakers,
     )
     total_time = time.time() - start_time

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - WEB_PORT=8000
       - MAX_FILE_SIZE=2147483648
       - MAX_CONCURRENT_TASKS=2
+      - AUDIO_PREPROCESSING_MODE=${AUDIO_PREPROCESSING_MODE:-auto}
       - UPLOAD_DIR=uploads
       - RESULTS_DIR=results
       - STATS_FILE=results/processing_stats.json
@@ -28,6 +29,8 @@ services:
       - PYTHONDONTWRITEBYTECODE=1
       - MPLCONFIGDIR=/tmp/matplotlib
       - XDG_CACHE_HOME=/tmp/cache
+      # DeepFilterNet is an executable; /tmp is mounted noexec for hardening.
+      - GIGAAM_DEEPFILTER_DIR=/home/gigaam/.cache/deepfilter
       - PYTHONWARNINGS=ignore::UserWarning:pyannote.audio.core.io,ignore::UserWarning:pyannote.audio.pipelines.speaker_verification,ignore::UserWarning:pyannote.audio.tasks.segmentation.mixins,ignore::UserWarning:pyannote.audio.utils.reproducibility
     security_opt:
       - no-new-privileges:true

--- a/src/config.py
+++ b/src/config.py
@@ -145,6 +145,9 @@ MLX_MODEL_REPO = os.getenv("MLX_MODEL_REPO", "aystream/GigaAM-v3-e2e-rnnt-mlx")
 # Настройки аудио конвертации
 AUDIO_SAMPLE_RATE = int(os.getenv("AUDIO_SAMPLE_RATE", "16000"))
 AUDIO_CHANNELS = int(os.getenv("AUDIO_CHANNELS", "1"))
+AUDIO_PREPROCESSING_MODE = os.getenv("AUDIO_PREPROCESSING_MODE", "auto").strip().lower()
+if AUDIO_PREPROCESSING_MODE not in {"off", "auto", "light", "denoise"}:
+    AUDIO_PREPROCESSING_MODE = "auto"
 
 # Настройки GUI
 APP_TITLE = os.getenv("APP_TITLE", "GigaAM v3 Transcriber")

--- a/src/core/processor.py
+++ b/src/core/processor.py
@@ -10,6 +10,8 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from ..utils.audio_converter import AudioConverter
+from ..utils.audio_preprocessing import AudioPreprocessor, FFmpegAudioPreprocessingBackend
+from ..utils.deepfilter_backend import DeepFilterNetBinaryBackend
 from ..utils.output_naming import output_path
 from ..utils.time_formatter import TimeFormatter
 from . import formatters
@@ -35,6 +37,10 @@ class TranscriptionProcessor:
         self.logger = logger or print
         self.progress_callback = progress_callback
         self.audio_converter = AudioConverter(self.logger)
+        self.audio_preprocessor = AudioPreprocessor(
+            dsp_backend=FFmpegAudioPreprocessingBackend(self.logger),
+            neural_backend=DeepFilterNetBinaryBackend(self.logger),
+        )
         self.time_formatter = TimeFormatter()
         self._diarization_manager = None
         self._active_diarization_backend = "pyannote"
@@ -129,7 +135,8 @@ class TranscriptionProcessor:
                      enable_diarization: bool = False,
                      num_speakers: int | None = None,
                      output_formats: list | None = None,
-                     diarization_backend: str = "pyannote") -> dict:
+                     diarization_backend: str = "pyannote",
+                     audio_preprocessing_mode: str = "off") -> dict:
         """
         Обрабатывает один файл
 
@@ -145,6 +152,7 @@ class TranscriptionProcessor:
             enable_diarization: включить диаризацию спикеров
             num_speakers: количество спикеров (если известно)
             diarization_backend: backend диаризации (`pyannote` или `sortformer`)
+            audio_preprocessing_mode: подготовка аудио (`off`, `auto`, `light` или `denoise`)
 
         Returns:
             dict: результаты обработки с ключами:
@@ -171,7 +179,9 @@ class TranscriptionProcessor:
             'media_duration': media_duration,
             'total_time': 0,
             'conversion_time': 0,
+            'preprocessing_time': 0,
             'transcription_time': 0,
+            'audio_preprocessing': None,
             'saved_files': []
         }
 
@@ -210,6 +220,46 @@ class TranscriptionProcessor:
             result['total_time'] = time.time() - file_start_time
             return result
 
+        # Подготовка создаёт отдельную дорожку только для ASR. Диаризация
+        # получает canonical WAV, чтобы не терять тембр и границы реплик.
+        asr_audio = temp_audio
+        diarization_audio = temp_audio
+        preprocessing_temp_paths: tuple[str, ...] = ()
+        preprocessing_start = time.time()
+        self._update_progress("preprocessing", 0.0, total_seconds=media_duration, processed_seconds=0.0)
+        try:
+            prepared_audio = self.audio_preprocessor.prepare(
+                temp_audio,
+                output_dir,
+                mode=audio_preprocessing_mode,
+            )
+            asr_audio = prepared_audio.asr_path
+            diarization_audio = prepared_audio.diarization_path
+            preprocessing_temp_paths = prepared_audio.temporary_paths
+            result['audio_preprocessing'] = prepared_audio.report.to_dict()
+            decision = prepared_audio.report.decision
+            self.logger(
+                "Предобработка аудио: "
+                f"режим={prepared_audio.report.mode}, действие={decision.action}, "
+                f"применено={'да' if prepared_audio.report.applied else 'нет'}"
+            )
+            for reason in decision.reasons:
+                self.logger(f"  Причина: {reason}")
+            if prepared_audio.report.runtime_fallback:
+                detail = prepared_audio.report.fallback_reason or "безопасный fallback к исходной дорожке"
+                self.logger(f"  Очистка не применена: {detail}")
+        except Exception as exc:
+            # Quality enhancement никогда не должен ломать базовую транскрибацию.
+            self.logger(f"Предобработка аудио недоступна, используется исходная дорожка: {exc}")
+        finally:
+            result['preprocessing_time'] = time.time() - preprocessing_start
+            self._update_progress(
+                "preprocessing",
+                1.0,
+                total_seconds=media_duration,
+                processed_seconds=media_duration if media_duration > 0 else None,
+            )
+
         # Транскрибация
         transcription_start = time.time()
         try:
@@ -217,7 +267,7 @@ class TranscriptionProcessor:
             # Транскрибация (обновляем прогресс постепенно)
             try:
                 utterances = self.model_loader.transcribe_longform(
-                    temp_audio,
+                    asr_audio,
                     progress_callback=lambda stage_progress, processed, total: self._update_progress(
                         "transcription",
                         stage_progress,
@@ -273,7 +323,7 @@ class TranscriptionProcessor:
                 try:
                     self._update_progress("diarization", None)
                     utterances = self._apply_diarization(
-                        temp_audio,
+                        diarization_audio,
                         utterances,
                         num_speakers=num_speakers,
                         progress_callback=lambda stage_progress, processed, total: self._update_progress(
@@ -466,10 +516,16 @@ class TranscriptionProcessor:
             traceback.print_exc()
 
         finally:
-            # Чистка временного файла
-            if temp_audio and os.path.exists(temp_audio):
+            # Удаляем только временные файлы текущего запуска; исходный файл
+            # не трогаем даже если внешний converter вернул тот же путь.
+            owned_temp_paths = {temp_audio, *preprocessing_temp_paths}
+            for temp_path in owned_temp_paths:
+                if not temp_path or os.path.abspath(temp_path) == os.path.abspath(filepath):
+                    continue
+                if not os.path.exists(temp_path):
+                    continue
                 try:
-                    os.remove(temp_audio)
+                    os.remove(temp_path)
                 except OSError:
                     pass
 

--- a/src/core/progress.py
+++ b/src/core/progress.py
@@ -6,7 +6,9 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Literal
 
-ProgressStage = Literal["preparing", "conversion", "transcription", "diarization", "export", "finalizing"]
+ProgressStage = Literal[
+    "preparing", "conversion", "preprocessing", "transcription", "diarization", "export", "finalizing"
+]
 
 
 ProgressCallback = Callable[[float, float | None, float | None], None]
@@ -45,6 +47,7 @@ class ProgressEvent:
 _ALL_STAGES: dict[str, None] = {
     "preparing": None,
     "conversion": None,
+    "preprocessing": None,
     "transcription": None,
     "diarization": None,
     "export": None,
@@ -57,7 +60,8 @@ class ProgressPlan:
 
     _PLAN_WITHOUT: dict[str, tuple[float, float]] = {
         "preparing": (0.0, 0.02),
-        "conversion": (0.02, 0.15),
+        "conversion": (0.02, 0.12),
+        "preprocessing": (0.12, 0.15),
         "transcription": (0.15, 0.95),
         "export": (0.95, 0.99),
         "finalizing": (0.99, 1.0),
@@ -65,7 +69,8 @@ class ProgressPlan:
 
     _PLAN_WITH: dict[str, tuple[float, float]] = {
         "preparing": (0.0, 0.02),
-        "conversion": (0.02, 0.12),
+        "conversion": (0.02, 0.10),
+        "preprocessing": (0.10, 0.12),
         "transcription": (0.12, 0.70),
         "diarization": (0.70, 0.95),
         "export": (0.95, 0.99),

--- a/src/gui/processing_mixin.py
+++ b/src/gui/processing_mixin.py
@@ -18,6 +18,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
+from ..config import AUDIO_PREPROCESSING_MODE
 from ..core.progress import ProgressEvent
 from ..services import transcription_service
 
@@ -137,6 +138,7 @@ class ProcessingMixin:
             "num_speakers": num_speakers,
             "enable_diarization": self.enable_diarization,
             "diarization_backend": self.diarization_backend,
+            "audio_preprocessing_mode": AUDIO_PREPROCESSING_MODE,
             "selected_formats": self._get_selected_formats(),
             "output_dir": self.output_dir,
             "files": list(self.files_to_process),
@@ -164,6 +166,7 @@ class ProcessingMixin:
         num_speakers = snapshot["num_speakers"]
         enable_diarization = snapshot["enable_diarization"]
         diarization_backend = snapshot["diarization_backend"]
+        audio_preprocessing_mode = snapshot["audio_preprocessing_mode"]
         selected_formats = snapshot["selected_formats"]
         output_dir = snapshot["output_dir"]
         files = snapshot["files"]
@@ -196,6 +199,7 @@ class ProcessingMixin:
                         filepath, file_output_dir, i, total_files,
                         enable_diarization=enable_diarization,
                         diarization_backend=diarization_backend,
+                        audio_preprocessing_mode=audio_preprocessing_mode,
                         num_speakers=num_speakers,
                         output_formats=selected_formats
                     )
@@ -255,6 +259,7 @@ class ProcessingMixin:
     _STAGE_NAMES = {
         'preparing': ('Подготовка…', 'Preparing…'),
         'conversion': ('Конвертация…', 'Converting…'),
+        'preprocessing': ('Анализ и подготовка аудио…', 'Analyzing and preparing audio…'),
         'transcription': ('Распознавание речи…', 'Speech recognition…'),
         'diarization': ('Диаризация…', 'Speaker diarization…'),
         'export': ('Экспорт…', 'Exporting…'),

--- a/src/tui_worker.py
+++ b/src/tui_worker.py
@@ -139,7 +139,7 @@ class TuiWorker:
         try:
             # Keep the protocol health check lightweight: ML dependencies load only
             # when a batch actually starts.
-            from src.config import STATS_FILE
+            from src.config import AUDIO_PREPROCESSING_MODE, STATS_FILE
             from src.core.model_loader import ModelLoader
             from src.core.progress import ProgressEvent
             from src.services.transcription_service import build_processor
@@ -187,6 +187,7 @@ class TuiWorker:
                         total_files=len(files),
                         enable_diarization=diarization,
                         diarization_backend=diarization_backend,
+                        audio_preprocessing_mode=AUDIO_PREPROCESSING_MODE,
                         num_speakers=num_speakers if isinstance(num_speakers, int) and num_speakers > 0 else None,
                         output_formats=formats,
                     )

--- a/src/utils/audio_preprocessing.py
+++ b/src/utils/audio_preprocessing.py
@@ -1,0 +1,704 @@
+"""Интеллектуальная диагностика качества аудио и консервативная policy очистки.
+
+Модуль намеренно не импортирует torch и необязательные ML-backend'ы. Анализ
+выполняется по репрезентативным окнам WAV и пригоден для длинных записей без
+загрузки файла целиком в память.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import subprocess
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from typing import Literal, Protocol
+
+import numpy as np
+import soundfile as sf
+
+from ..config import AUDIO_CHANNELS, AUDIO_SAMPLE_RATE
+from .audio_converter import _find_ffmpeg, _windows_startupinfo
+
+PreprocessingMode = Literal["off", "auto", "light", "denoise"]
+PreprocessingAction = Literal["none", "normalize", "light_cleanup", "neural_denoise"]
+
+_MODE_ALIASES = {
+    "disabled": "off",
+    "disable": "off",
+    "none": "off",
+    "false": "off",
+    "neural": "denoise",
+    "deepfilter": "denoise",
+    "deepfilternet": "denoise",
+}
+_SUPPORTED_MODES = {"off", "auto", "light", "denoise"}
+
+
+def normalize_preprocessing_mode(value: str | None) -> PreprocessingMode:
+    """Возвращает каноническое имя режима или сообщает об ошибке явно."""
+
+    normalized = (value or "off").strip().lower()
+    normalized = _MODE_ALIASES.get(normalized, normalized)
+    if normalized not in _SUPPORTED_MODES:
+        raise ValueError(f"Unsupported audio preprocessing mode: {value!r}")
+    return normalized  # type: ignore[return-value]
+
+
+def _finite_float(value: float, *, default: float = 0.0) -> float:
+    numeric = float(value)
+    return numeric if math.isfinite(numeric) else default
+
+
+@dataclass(frozen=True)
+class AudioQualityMetrics:
+    """Измеримые признаки входного аудио, используемые policy."""
+
+    duration_seconds: float
+    sample_rate: int
+    channels: int
+    rms_dbfs: float
+    peak_dbfs: float
+    noise_floor_dbfs: float
+    estimated_snr_db: float
+    clipping_ratio: float
+    silence_ratio: float
+    dc_offset: float
+    spectral_flatness: float
+    low_frequency_ratio: float
+    analyzed_fraction: float
+
+    def to_dict(self) -> dict[str, float | int]:
+        payload = asdict(self)
+        for key, value in payload.items():
+            if isinstance(value, float):
+                payload[key] = round(_finite_float(value), 6)
+        return payload
+
+
+@dataclass(frozen=True)
+class PreprocessingDecision:
+    """Объяснимое решение о безопасном уровне обработки."""
+
+    action: PreprocessingAction
+    confidence: float
+    reasons: tuple[str, ...]
+    use_neural: bool
+    fallback: bool = False
+    refused: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "action": self.action,
+            "confidence": round(min(max(_finite_float(self.confidence), 0.0), 1.0), 6),
+            "reasons": list(self.reasons),
+            "use_neural": self.use_neural,
+            "fallback": self.fallback,
+            "refused": self.refused,
+        }
+
+
+@dataclass(frozen=True)
+class AudioPreprocessingReport:
+    """Serializable diagnostics and runtime outcome for one input file."""
+
+    mode: PreprocessingMode
+    metrics: AudioQualityMetrics | None
+    decision: PreprocessingDecision
+    applied: bool
+    backend: str | None = None
+    runtime_fallback: bool = False
+    fallback_reason: str | None = None
+    processed_metrics: AudioQualityMetrics | None = None
+    elapsed_seconds: float = 0.0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "mode": self.mode,
+            "metrics": self.metrics.to_dict() if self.metrics else None,
+            "decision": self.decision.to_dict(),
+            "applied": self.applied,
+            "backend": self.backend,
+            "runtime_fallback": self.runtime_fallback,
+            "fallback_reason": self.fallback_reason,
+            "processed_metrics": (
+                self.processed_metrics.to_dict() if self.processed_metrics else None
+            ),
+            "elapsed_seconds": round(max(_finite_float(self.elapsed_seconds), 0.0), 6),
+        }
+
+
+@dataclass(frozen=True)
+class PreprocessedAudio:
+    """Aligned tracks prepared for downstream models."""
+
+    asr_path: str
+    diarization_path: str
+    temporary_paths: tuple[str, ...]
+    report: AudioPreprocessingReport
+
+
+class DspPreprocessingBackend(Protocol):
+    def process(self, input_path: str, output_dir: str, action: str) -> str | None: ...
+
+
+class NeuralPreprocessingBackend(Protocol):
+    def is_available(self) -> bool: ...
+
+    def process(self, input_path: str, output_dir: str) -> str | None: ...
+
+
+@dataclass(frozen=True)
+class AudioPreprocessingPolicy:
+    """Детерминированная conservative policy с явными порогами."""
+
+    severe_clipping_ratio: float = 0.02
+    almost_silent_ratio: float = 0.97
+    almost_silent_rms_dbfs: float = -60.0
+    quiet_rms_dbfs: float = -32.0
+    clean_snr_db: float = 22.0
+    severe_noise_snr_db: float = 8.0
+    moderate_flatness: float = 0.08
+    severe_flatness: float = 0.18
+    audible_noise_floor_dbfs: float = -50.0
+    rumble_ratio: float = 0.12
+
+    def decide(
+        self,
+        metrics: AudioQualityMetrics,
+        *,
+        neural_available: bool,
+    ) -> PreprocessingDecision:
+        """Выбирает минимальное воздействие; при сомнении оставляет исходник."""
+
+        if metrics.clipping_ratio >= self.severe_clipping_ratio:
+            return PreprocessingDecision(
+                action="none",
+                confidence=0.98,
+                reasons=(
+                    "Severe clipping detected; denoising cannot restore clipped speech safely",
+                ),
+                use_neural=False,
+                refused=True,
+            )
+
+        if (
+            metrics.silence_ratio >= self.almost_silent_ratio
+            or metrics.rms_dbfs <= self.almost_silent_rms_dbfs
+        ):
+            return PreprocessingDecision(
+                action="none",
+                confidence=0.97,
+                reasons=("Almost no analyzable speech signal; processing refused",),
+                use_neural=False,
+                refused=True,
+            )
+
+        severe_noise = (
+            metrics.estimated_snr_db <= self.severe_noise_snr_db
+            and metrics.spectral_flatness >= self.severe_flatness
+        )
+        if severe_noise:
+            if neural_available:
+                return PreprocessingDecision(
+                    action="neural_denoise",
+                    confidence=0.86,
+                    reasons=("Severe broadband noise detected",),
+                    use_neural=True,
+                )
+            return PreprocessingDecision(
+                action="light_cleanup",
+                confidence=0.66,
+                reasons=(
+                    "Severe broadband noise detected",
+                    "Neural denoiser unavailable; using conservative FFmpeg cleanup",
+                ),
+                use_neural=False,
+                fallback=True,
+            )
+
+        broadband_noise = (
+            metrics.noise_floor_dbfs >= self.audible_noise_floor_dbfs
+            and metrics.estimated_snr_db < self.clean_snr_db
+            and metrics.spectral_flatness >= self.moderate_flatness
+        )
+        moderate_noise = broadband_noise or metrics.low_frequency_ratio >= self.rumble_ratio
+        if moderate_noise:
+            reasons: list[str] = []
+            if broadband_noise:
+                reasons.append("Reduced estimated signal-to-noise ratio")
+                reasons.append("Broadband stationary noise signature")
+            if metrics.low_frequency_ratio >= self.rumble_ratio:
+                reasons.append("Low-frequency rumble signature")
+            return PreprocessingDecision(
+                action="light_cleanup",
+                confidence=0.78,
+                reasons=tuple(reasons),
+                use_neural=False,
+            )
+
+        if metrics.rms_dbfs <= self.quiet_rms_dbfs:
+            if metrics.estimated_snr_db < self.clean_snr_db:
+                return PreprocessingDecision(
+                    action="none",
+                    confidence=0.74,
+                    reasons=(
+                        "Signal is quiet but estimated SNR is uncertain; amplification refused",
+                    ),
+                    use_neural=False,
+                    refused=True,
+                )
+            return PreprocessingDecision(
+                action="normalize",
+                confidence=0.88,
+                reasons=("Speech level is low while signal-to-noise ratio is healthy",),
+                use_neural=False,
+            )
+
+        return PreprocessingDecision(
+            action="none",
+            confidence=0.93,
+            reasons=("Input appears clean; enhancement is unnecessary",),
+            use_neural=False,
+        )
+
+
+class AudioQualityAnalyzer:
+    """Оценивает WAV по ограниченному набору репрезентативных окон."""
+
+    def __init__(
+        self,
+        *,
+        max_analysis_seconds: float = 120.0,
+        window_seconds: float = 10.0,
+        silence_threshold_dbfs: float = -50.0,
+    ) -> None:
+        self.max_analysis_seconds = max(float(max_analysis_seconds), 1.0)
+        self.window_seconds = max(float(window_seconds), 0.25)
+        self.silence_threshold = 10.0 ** (float(silence_threshold_dbfs) / 20.0)
+
+    @staticmethod
+    def _dbfs(value: float, *, floor: float = -120.0) -> float:
+        if value <= 0.0 or not math.isfinite(value):
+            return floor
+        return max(20.0 * math.log10(value), floor)
+
+    def _read_representative_audio(self, audio: sf.SoundFile) -> tuple[np.ndarray, float]:
+        total_frames = len(audio)
+        if total_frames <= 0 or audio.samplerate <= 0:
+            raise ValueError("Audio file has no readable samples")
+
+        max_frames = max(int(self.max_analysis_seconds * audio.samplerate), 1)
+        window_frames = max(int(self.window_seconds * audio.samplerate), 1)
+        if total_frames <= max_frames:
+            audio.seek(0)
+            data = audio.read(total_frames, dtype="float32", always_2d=True)
+            return data, 1.0
+
+        window_count = max(max_frames // window_frames, 1)
+        max_start = max(total_frames - window_frames, 0)
+        starts = np.linspace(0, max_start, num=window_count, dtype=np.int64)
+        chunks: list[np.ndarray] = []
+        for start in starts:
+            audio.seek(int(start))
+            chunk = audio.read(window_frames, dtype="float32", always_2d=True)
+            if chunk.size:
+                chunks.append(chunk)
+        if not chunks:
+            raise ValueError("Audio file has no analyzable samples")
+        data = np.concatenate(chunks, axis=0)
+        return data, min(data.shape[0] / total_frames, 1.0)
+
+    @staticmethod
+    def _frame_rms(samples: np.ndarray, frame_size: int) -> np.ndarray:
+        usable = samples.size - (samples.size % frame_size)
+        if usable <= 0:
+            return np.asarray([float(np.sqrt(np.mean(np.square(samples), dtype=np.float64)))])
+        framed = samples[:usable].reshape(-1, frame_size)
+        return np.sqrt(np.mean(np.square(framed), axis=1, dtype=np.float64))
+
+    def analyze(self, path: str) -> AudioQualityMetrics:
+        try:
+            with sf.SoundFile(path) as audio:
+                sample_rate = int(audio.samplerate)
+                channels = int(audio.channels)
+                duration = len(audio) / sample_rate if sample_rate > 0 else 0.0
+                data, analyzed_fraction = self._read_representative_audio(audio)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ValueError(f"Unable to analyze audio/WAV file: {exc}") from exc
+
+        mono = np.mean(data, axis=1, dtype=np.float32)
+        if mono.size == 0:
+            raise ValueError("Audio file has no analyzable samples")
+        finite = np.nan_to_num(mono, nan=0.0, posinf=1.0, neginf=-1.0)
+        absolute = np.abs(finite)
+        rms = float(np.sqrt(np.mean(np.square(finite), dtype=np.float64)))
+        peak = float(np.max(absolute))
+        clipping_ratio = float(np.mean(absolute >= 0.999))
+        silence_ratio = float(np.mean(absolute <= self.silence_threshold))
+        dc_offset = float(np.mean(finite, dtype=np.float64))
+
+        frame_size = max(int(sample_rate * 0.02), 1)
+        frame_rms = self._frame_rms(finite, frame_size)
+        if frame_rms.size:
+            noise_rms = float(np.percentile(frame_rms, 20.0))
+            speech_rms = float(np.percentile(frame_rms, 80.0))
+        else:
+            noise_rms = 0.0
+            speech_rms = 0.0
+        noise_floor_dbfs = self._dbfs(noise_rms)
+        estimated_snr_db = min(max(self._dbfs(speech_rms) - noise_floor_dbfs, 0.0), 60.0)
+
+        spectral_limit = max(sample_rate * 20, 4096)
+        usable = finite.size - (finite.size % frame_size)
+        spectral_samples = finite[: min(finite.size, spectral_limit)]
+        if usable > 0:
+            framed = finite[:usable].reshape(-1, frame_size)
+            valid_noise_frames = (frame_rms > 1e-8) & (
+                frame_rms <= np.percentile(frame_rms[frame_rms > 1e-8], 25.0)
+            ) if np.any(frame_rms > 1e-8) else np.zeros(frame_rms.shape, dtype=bool)
+            if np.any(valid_noise_frames) and noise_floor_dbfs > -60.0:
+                spectral_samples = framed[valid_noise_frames].reshape(-1)[:spectral_limit]
+        if spectral_samples.size < 2:
+            spectral_flatness = 0.0
+            low_frequency_ratio = 0.0
+        else:
+            window = np.hanning(spectral_samples.size).astype(np.float32)
+            power = np.square(np.abs(np.fft.rfft(spectral_samples * window))).astype(np.float64)
+            power = np.maximum(power, 1e-20)
+            spectral_flatness = float(np.exp(np.mean(np.log(power))) / np.mean(power))
+            frequencies = np.fft.rfftfreq(spectral_samples.size, d=1.0 / sample_rate)
+            total_power = float(np.sum(power))
+            low_frequency_ratio = (
+                float(np.sum(power[frequencies <= 80.0])) / total_power
+                if total_power > 0.0
+                else 0.0
+            )
+
+        return AudioQualityMetrics(
+            duration_seconds=_finite_float(duration),
+            sample_rate=sample_rate,
+            channels=channels,
+            rms_dbfs=self._dbfs(rms),
+            peak_dbfs=self._dbfs(peak),
+            noise_floor_dbfs=noise_floor_dbfs,
+            estimated_snr_db=_finite_float(estimated_snr_db),
+            clipping_ratio=min(max(_finite_float(clipping_ratio), 0.0), 1.0),
+            silence_ratio=min(max(_finite_float(silence_ratio), 0.0), 1.0),
+            dc_offset=_finite_float(dc_offset),
+            spectral_flatness=min(max(_finite_float(spectral_flatness), 0.0), 1.0),
+            low_frequency_ratio=min(max(_finite_float(low_frequency_ratio), 0.0), 1.0),
+            analyzed_fraction=min(max(_finite_float(analyzed_fraction), 0.0), 1.0),
+        )
+
+
+class FFmpegAudioPreprocessingBackend:
+    """Conservative non-ML cleanup with strict timeline verification."""
+
+    _FILTERS = {
+        # A bounded linear gain is safer for ASR than dynamic loudnorm, which can
+        # oversample internally and reshape dynamics. Auto chooses this only for
+        # quiet, otherwise healthy recordings.
+        "normalize": "volume=6dB",
+        "light_cleanup": (
+            "highpass=f=70,"
+            "afftdn=nr=8:nf=-40:tn=1"
+        ),
+    }
+
+    def __init__(
+        self,
+        logger=None,
+        *,
+        duration_tolerance_seconds: float = 2.0 / AUDIO_SAMPLE_RATE,
+    ) -> None:
+        self.logger = logger or (lambda _message: None)
+        self.duration_tolerance_seconds = max(float(duration_tolerance_seconds), 0.0)
+
+    @staticmethod
+    def _duration(path: str) -> float:
+        try:
+            info = sf.info(path)
+        except (OSError, RuntimeError) as exc:
+            raise ValueError(f"Cannot inspect processed WAV: {exc}") from exc
+        if info.samplerate <= 0 or info.frames <= 0:
+            raise ValueError("Processed WAV has no readable samples")
+        return float(info.frames) / float(info.samplerate)
+
+    @staticmethod
+    def _remove_partial(path: str) -> None:
+        try:
+            if os.path.exists(path):
+                os.remove(path)
+        except OSError:
+            pass
+
+    def process(self, input_path: str, output_dir: str, action: str) -> str | None:
+        filters = self._FILTERS.get(action)
+        if filters is None:
+            self.logger(f"Audio cleanup skipped: unsupported FFmpeg action {action!r}")
+            return None
+
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(
+            output_dir,
+            f"temp_preprocessed_{uuid.uuid4().hex}.wav",
+        )
+        try:
+            source_duration = self._duration(input_path)
+            timeout = max(120.0, min(7200.0, source_duration * 3.0 + 60.0))
+            command = [
+                _find_ffmpeg(),
+                "-hide_banner",
+                "-nostdin",
+                "-i",
+                input_path,
+                "-af",
+                filters,
+                "-ar",
+                str(AUDIO_SAMPLE_RATE),
+                "-ac",
+                str(AUDIO_CHANNELS),
+                "-c:a",
+                "pcm_s16le",
+                "-vn",
+                "-y",
+                output_path,
+            ]
+            completed = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                startupinfo=_windows_startupinfo(),
+                timeout=timeout,
+            )
+            if completed.returncode != 0:
+                self.logger(f"FFmpeg audio cleanup failed with code {completed.returncode}")
+                self._remove_partial(output_path)
+                return None
+
+            output_duration = self._duration(output_path)
+            drift = abs(output_duration - source_duration)
+            if drift > self.duration_tolerance_seconds:
+                self.logger(
+                    "Audio cleanup rejected because timeline drifted by "
+                    f"{drift:.3f}s (limit {self.duration_tolerance_seconds:.3f}s)"
+                )
+                self._remove_partial(output_path)
+                return None
+            return output_path
+        except (OSError, ValueError, subprocess.SubprocessError) as exc:
+            self.logger(f"Audio cleanup failed safely: {exc}")
+            self._remove_partial(output_path)
+            return None
+
+
+class AudioPreprocessor:
+    """Coordinates diagnostics and creates aligned ASR/diarization tracks.
+
+    The canonical input is always retained for diarization. Enhancement is
+    routed to ASR only, because aggressive cleanup can damage speaker cues.
+    """
+
+    def __init__(
+        self,
+        *,
+        analyzer: AudioQualityAnalyzer | None = None,
+        policy: AudioPreprocessingPolicy | None = None,
+        dsp_backend: DspPreprocessingBackend | None = None,
+        neural_backend: NeuralPreprocessingBackend | None = None,
+    ) -> None:
+        self.analyzer = analyzer or AudioQualityAnalyzer()
+        self.policy = policy or AudioPreprocessingPolicy()
+        self.dsp_backend = dsp_backend
+        self.neural_backend = neural_backend
+
+    @staticmethod
+    def _disabled_decision() -> PreprocessingDecision:
+        return PreprocessingDecision(
+            action="none",
+            confidence=1.0,
+            reasons=("Audio preprocessing is disabled",),
+            use_neural=False,
+        )
+
+    def _neural_available(self) -> bool:
+        if self.neural_backend is None:
+            return False
+        try:
+            return bool(self.neural_backend.is_available())
+        except Exception:
+            return False
+
+    def _forced_decision(
+        self,
+        mode: PreprocessingMode,
+        metrics: AudioQualityMetrics,
+        *,
+        neural_available: bool,
+    ) -> PreprocessingDecision:
+        safety = self.policy.decide(metrics, neural_available=neural_available)
+        if safety.refused:
+            return safety
+        if mode == "light":
+            return PreprocessingDecision(
+                action="light_cleanup",
+                confidence=1.0,
+                reasons=("Light cleanup explicitly requested",),
+                use_neural=False,
+            )
+        if mode == "denoise":
+            if neural_available:
+                return PreprocessingDecision(
+                    action="neural_denoise",
+                    confidence=1.0,
+                    reasons=("Neural denoising explicitly requested",),
+                    use_neural=True,
+                )
+            return PreprocessingDecision(
+                action="light_cleanup",
+                confidence=0.6,
+                reasons=(
+                    "Neural denoising explicitly requested",
+                    "Neural denoiser unavailable; using conservative FFmpeg cleanup",
+                ),
+                use_neural=False,
+                fallback=True,
+            )
+        return safety
+
+    @staticmethod
+    def _quality_gate(
+        source: AudioQualityMetrics,
+        candidate: AudioQualityMetrics,
+        action: PreprocessingAction,
+    ) -> tuple[bool, str | None]:
+        """Reject enhancement artifacts using conservative no-reference checks."""
+        clipping_limit = max(source.clipping_ratio + 0.002, 0.005)
+        if candidate.clipping_ratio > clipping_limit:
+            return False, "Quality gate rejected candidate: clipping increased"
+        if candidate.silence_ratio > source.silence_ratio + 0.20:
+            return False, "Quality gate rejected candidate: too much speech became silence"
+        if candidate.rms_dbfs < -45.0 and source.rms_dbfs >= -45.0:
+            return False, "Quality gate rejected candidate: useful signal level collapsed"
+
+        if action == "normalize":
+            before = abs(source.rms_dbfs - (-23.0))
+            after = abs(candidate.rms_dbfs - (-23.0))
+            if after > before + 1.0:
+                return False, "Quality gate rejected candidate: loudness moved away from target"
+            return True, None
+
+        noise_floor_improved = candidate.noise_floor_dbfs <= source.noise_floor_dbfs - 1.0
+        flatness_improved = candidate.spectral_flatness <= source.spectral_flatness * 0.95
+        snr_improved = candidate.estimated_snr_db >= source.estimated_snr_db + 2.0
+        if not (noise_floor_improved or flatness_improved or snr_improved):
+            return False, "Quality gate rejected candidate: no measurable cleanup benefit"
+        return True, None
+
+    @staticmethod
+    def _discard_candidate(path: str | None, canonical_path: str) -> None:
+        if not path or path == canonical_path:
+            return
+        try:
+            if os.path.exists(path):
+                os.remove(path)
+        except OSError:
+            pass
+
+    def prepare(
+        self,
+        canonical_path: str,
+        output_dir: str,
+        *,
+        mode: str = "off",
+    ) -> PreprocessedAudio:
+        started = time.monotonic()
+        normalized_mode = normalize_preprocessing_mode(mode)
+        if normalized_mode == "off":
+            report = AudioPreprocessingReport(
+                mode=normalized_mode,
+                metrics=None,
+                decision=self._disabled_decision(),
+                applied=False,
+                elapsed_seconds=time.monotonic() - started,
+            )
+            return PreprocessedAudio(canonical_path, canonical_path, (), report)
+
+        metrics = self.analyzer.analyze(canonical_path)
+        neural_available = self._neural_available()
+        if normalized_mode == "auto":
+            decision = self.policy.decide(metrics, neural_available=neural_available)
+        else:
+            decision = self._forced_decision(
+                normalized_mode,
+                metrics,
+                neural_available=neural_available,
+            )
+
+        if decision.action == "none":
+            report = AudioPreprocessingReport(
+                mode=normalized_mode,
+                metrics=metrics,
+                decision=decision,
+                applied=False,
+                elapsed_seconds=time.monotonic() - started,
+            )
+            return PreprocessedAudio(canonical_path, canonical_path, (), report)
+
+        backend_name: str | None = None
+        output_path: str | None = None
+        try:
+            if decision.use_neural and self.neural_backend is not None:
+                backend_name = "neural"
+                output_path = self.neural_backend.process(canonical_path, output_dir)
+            elif self.dsp_backend is not None:
+                backend_name = "ffmpeg"
+                output_path = self.dsp_backend.process(
+                    canonical_path,
+                    output_dir,
+                    decision.action,
+                )
+        except Exception:
+            output_path = None
+
+        applied = bool(output_path and output_path != canonical_path)
+        processed_metrics: AudioQualityMetrics | None = None
+        fallback_reason: str | None = None
+        if applied and output_path is not None:
+            try:
+                processed_metrics = self.analyzer.analyze(output_path)
+                accepted, fallback_reason = self._quality_gate(
+                    metrics,
+                    processed_metrics,
+                    decision.action,
+                )
+            except Exception as exc:
+                accepted = False
+                fallback_reason = f"Quality gate could not validate candidate: {exc}"
+            if not accepted:
+                self._discard_candidate(output_path, canonical_path)
+                output_path = None
+                applied = False
+        elif not applied:
+            fallback_reason = "Selected preprocessing backend failed safely"
+
+        report = AudioPreprocessingReport(
+            mode=normalized_mode,
+            metrics=metrics,
+            decision=decision,
+            applied=applied,
+            backend=backend_name,
+            runtime_fallback=not applied,
+            fallback_reason=fallback_reason,
+            processed_metrics=processed_metrics,
+            elapsed_seconds=time.monotonic() - started,
+        )
+        if not applied:
+            return PreprocessedAudio(canonical_path, canonical_path, (), report)
+        if output_path is None:
+            raise RuntimeError("Applied preprocessing did not produce an output path")
+        return PreprocessedAudio(output_path, canonical_path, (output_path,), report)

--- a/src/utils/deepfilter_backend.py
+++ b/src/utils/deepfilter_backend.py
@@ -1,0 +1,283 @@
+"""Optional DeepFilterNet backend using the dependency-free official Rust binary.
+
+The official Python package pins NumPy < 2 and conflicts with the application's
+NumPy 2 runtime. The signed-by-checksum standalone binary avoids mutating the
+PyTorch/NumPy environment and contains the pretrained model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+import soundfile as sf
+
+from ..config import AUDIO_CHANNELS, AUDIO_SAMPLE_RATE
+from .audio_converter import _find_ffmpeg, _windows_startupinfo
+from .runtime_manager import base_dir
+
+_DEEPFILTER_VERSION = "0.5.6"
+_RELEASE_BASE_URL = (
+    "https://github.com/Rikorose/DeepFilterNet/releases/download/"
+    f"v{_DEEPFILTER_VERSION}"
+)
+
+
+@dataclass(frozen=True)
+class DeepFilterAsset:
+    filename: str
+    sha256: str
+
+    @property
+    def url(self) -> str:
+        return f"{_RELEASE_BASE_URL}/{self.filename}"
+
+
+_ASSETS: dict[tuple[str, str], DeepFilterAsset] = {
+    ("linux", "x86_64"): DeepFilterAsset(
+        "deep-filter-0.5.6-x86_64-unknown-linux-musl",
+        "70775e251eee44c0f2451a1e833326cf8bcbbe304d3e7cd12851e6fce72ef7da",
+    ),
+    ("linux", "aarch64"): DeepFilterAsset(
+        "deep-filter-0.5.6-aarch64-unknown-linux-gnu",
+        "14e02a1c0028f3ca0bdf83b62b3336e56ba0556894ef295a95e8573f06557166",
+    ),
+    ("darwin", "arm64"): DeepFilterAsset(
+        "deep-filter-0.5.6-aarch64-apple-darwin",
+        "4601e7f4e4c03e59a4c5b5000216ef3add3e808799cfccd95e14e83ea4611081",
+    ),
+    ("darwin", "x86_64"): DeepFilterAsset(
+        "deep-filter-0.5.6-x86_64-apple-darwin",
+        "d3be84003acb7c23e738ad7f70a158ec779a8d233a82e7fa3e717d112eb5b50f",
+    ),
+    ("win32", "amd64"): DeepFilterAsset(
+        "deep-filter-0.5.6-x86_64-pc-windows-msvc.exe",
+        "75e11fa16445f560cb6b021521ddb89e89270d13b83089705d98776f58fd7915",
+    ),
+    ("win32", "x86_64"): DeepFilterAsset(
+        "deep-filter-0.5.6-x86_64-pc-windows-msvc.exe",
+        "75e11fa16445f560cb6b021521ddb89e89270d13b83089705d98776f58fd7915",
+    ),
+}
+
+
+def _asset_for(system: str | None = None, machine: str | None = None) -> DeepFilterAsset | None:
+    normalized_system = (system or sys.platform).lower()
+    normalized_machine = (machine or platform.machine()).lower()
+    aliases = {"arm64": "aarch64"} if normalized_system == "linux" else {"aarch64": "arm64"}
+    normalized_machine = aliases.get(normalized_machine, normalized_machine)
+    return _ASSETS.get((normalized_system, normalized_machine))
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+class DeepFilterBinaryManager:
+    """Downloads a pinned official binary atomically and verifies SHA-256."""
+
+    _download_lock = threading.Lock()
+    _max_download_bytes = 256 * 1024 * 1024
+
+    def __init__(
+        self,
+        *,
+        cache_dir: str | Path | None = None,
+        asset: DeepFilterAsset | None = None,
+    ) -> None:
+        configured_cache = os.environ.get("GIGAAM_DEEPFILTER_DIR")
+        self.cache_dir = Path(
+            cache_dir
+            or configured_cache
+            or (base_dir() / "audio-enhancement" / _DEEPFILTER_VERSION)
+        )
+        self.asset = asset or _asset_for()
+
+    def supported(self) -> bool:
+        return self.asset is not None
+
+    @staticmethod
+    def _trusted_download_url(url: str) -> bool:
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").lower()
+        return parsed.scheme == "https" and (
+            hostname == "github.com" or hostname.endswith(".githubusercontent.com")
+        )
+
+    @classmethod
+    def _download(cls, url: str, target: Path) -> None:
+        if not cls._trusted_download_url(url):
+            raise RuntimeError("DeepFilterNet download URL must use trusted GitHub HTTPS")
+        request = urllib.request.Request(url, headers={"User-Agent": "GigaAMGUI-audio-enhancement"})
+        # URL and redirect targets are allowlisted above/below; checksum validation
+        # in ensure() remains the final fail-closed integrity gate.
+        with urllib.request.urlopen(request, timeout=120) as response, target.open("wb") as output:  # nosec B310
+            final_url = response.geturl()
+            if not cls._trusted_download_url(final_url):
+                raise RuntimeError("DeepFilterNet download redirected outside trusted GitHub HTTPS")
+            content_length = response.headers.get("Content-Length")
+            if content_length and int(content_length) > cls._max_download_bytes:
+                raise RuntimeError("DeepFilterNet download exceeds the size limit")
+            downloaded = 0
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                downloaded += len(chunk)
+                if downloaded > cls._max_download_bytes:
+                    raise RuntimeError("DeepFilterNet download exceeds the size limit")
+                output.write(chunk)
+
+    def ensure(self) -> str:
+        if self.asset is None:
+            raise RuntimeError("DeepFilterNet binary is unavailable for this OS/architecture")
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        target = self.cache_dir / self.asset.filename
+        with self._download_lock:
+            if target.is_symlink():
+                target.unlink()
+            if target.is_file() and _sha256(target) == self.asset.sha256:
+                if os.name != "nt":
+                    target.chmod(target.stat().st_mode | 0o111)
+                return str(target)
+            target.unlink(missing_ok=True)
+            temporary = target.with_name(f".{target.name}.{uuid.uuid4().hex}.download")
+            try:
+                self._download(self.asset.url, temporary)
+                actual = _sha256(temporary)
+                if actual != self.asset.sha256:
+                    raise RuntimeError(
+                        f"DeepFilterNet checksum mismatch: expected {self.asset.sha256}, got {actual}"
+                    )
+                if os.name != "nt":
+                    temporary.chmod(0o755)
+                os.replace(temporary, target)
+            finally:
+                temporary.unlink(missing_ok=True)
+        return str(target)
+
+
+class DeepFilterNetBinaryBackend:
+    """Runs the official model with bounded attenuation and exact duration."""
+
+    _inference_lock = threading.Lock()
+
+    def __init__(
+        self,
+        logger=None,
+        *,
+        manager: DeepFilterBinaryManager | None = None,
+        attenuation_limit_db: float = 18.0,
+    ) -> None:
+        self.logger = logger or (lambda _message: None)
+        self.manager = manager or DeepFilterBinaryManager()
+        self.attenuation_limit_db = min(max(float(attenuation_limit_db), 0.0), 100.0)
+
+    def is_available(self) -> bool:
+        return self.manager.supported()
+
+    @staticmethod
+    def _duration(path: str) -> float:
+        info = sf.info(path)
+        if info.samplerate <= 0 or info.frames <= 0:
+            raise ValueError("Audio has no readable samples")
+        return float(info.frames) / float(info.samplerate)
+
+    def _run(self, command: list[str], *, timeout: float) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            startupinfo=_windows_startupinfo(),
+            timeout=timeout,
+        )
+
+    def process(self, input_path: str, output_dir: str) -> str | None:
+        os.makedirs(output_dir, exist_ok=True)
+        source_duration = self._duration(input_path)
+        timeout = max(180.0, min(7200.0, source_duration * 6.0 + 120.0))
+        final_path = os.path.join(output_dir, f"temp_deepfiltered_{uuid.uuid4().hex}.wav")
+        workspace: Path | None = None
+
+        try:
+            workspace = Path(tempfile.mkdtemp(prefix="gigaam_deepfilter_", dir=output_dir))
+            input_dir = workspace / "input"
+            enhanced_dir = workspace / "enhanced"
+            input_dir.mkdir()
+            enhanced_dir.mkdir()
+            fullband_input = input_dir / "audio.wav"
+            fullband_output = enhanced_dir / "audio.wav"
+
+            self.logger("DeepFilterNet: проверка локального backend и модели…")
+            binary = self.manager.ensure()
+            self.logger("DeepFilterNet: нейросетевое шумоподавление…")
+            decode = self._run(
+                [
+                    _find_ffmpeg(), "-hide_banner", "-nostdin", "-i", input_path,
+                    "-ar", "48000", "-ac", "1", "-c:a", "pcm_s16le", "-vn", "-y",
+                    str(fullband_input),
+                ],
+                timeout=timeout,
+            )
+            if decode.returncode != 0:
+                raise RuntimeError("FFmpeg could not prepare 48 kHz audio for DeepFilterNet")
+
+            with self._inference_lock:
+                enhanced = self._run(
+                    [
+                        binary,
+                        "-D",
+                        "--atten-lim-db", f"{self.attenuation_limit_db:g}",
+                        "--output-dir", str(enhanced_dir),
+                        str(fullband_input),
+                    ],
+                    timeout=timeout,
+                )
+            if enhanced.returncode != 0 or not fullband_output.is_file():
+                raise RuntimeError("DeepFilterNet inference failed")
+
+            # DeepFilterNet compensation can differ by a few milliseconds.
+            # Pad/trim the tail to the canonical duration without shifting t=0.
+            duration_text = f"{source_duration:.9f}"
+            finalize = self._run(
+                [
+                    _find_ffmpeg(), "-hide_banner", "-nostdin", "-i", str(fullband_output),
+                    "-af", f"apad,atrim=duration={duration_text}",
+                    "-ar", str(AUDIO_SAMPLE_RATE), "-ac", str(AUDIO_CHANNELS),
+                    "-c:a", "pcm_s16le", "-vn", "-y", final_path,
+                ],
+                timeout=timeout,
+            )
+            if finalize.returncode != 0 or not os.path.isfile(final_path):
+                raise RuntimeError("FFmpeg could not finalize DeepFilterNet output")
+            drift = abs(self._duration(final_path) - source_duration)
+            if drift > 2.0 / AUDIO_SAMPLE_RATE:
+                raise RuntimeError(f"DeepFilterNet timeline drift is unsafe: {drift:.6f}s")
+            return final_path
+        except (OSError, ValueError, RuntimeError, subprocess.SubprocessError) as exc:
+            self.logger(f"DeepFilterNet unavailable; using safe fallback: {exc}")
+            try:
+                os.remove(final_path)
+            except OSError:
+                pass
+            return None
+        finally:
+            if workspace is not None:
+                shutil.rmtree(workspace, ignore_errors=True)

--- a/tests/test_api_progress.py
+++ b/tests/test_api_progress.py
@@ -54,7 +54,9 @@ def test_process_transcription_persists_progress_metadata_from_events(monkeypatc
             enable_diarization=False,
             num_speakers=None,
             output_formats=None,
+            audio_preprocessing_mode="auto",
         ):
+            assert audio_preprocessing_mode == "auto"
             if self.progress_callback:
                 self.progress_callback({
                     "stage": "conversion",

--- a/tests/test_audio_preprocessing.py
+++ b/tests/test_audio_preprocessing.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import json
+import math
+import shutil
+import wave
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+
+from src.utils.audio_preprocessing import (
+    AudioPreprocessingPolicy,
+    AudioPreprocessor,
+    AudioQualityAnalyzer,
+    AudioQualityMetrics,
+    FFmpegAudioPreprocessingBackend,
+    PreprocessingDecision,
+    normalize_preprocessing_mode,
+)
+
+
+def _metrics(**overrides) -> AudioQualityMetrics:
+    base = AudioQualityMetrics(
+        duration_seconds=60.0,
+        sample_rate=16000,
+        channels=1,
+        rms_dbfs=-19.0,
+        peak_dbfs=-3.0,
+        noise_floor_dbfs=-48.0,
+        estimated_snr_db=29.0,
+        clipping_ratio=0.0,
+        silence_ratio=0.12,
+        dc_offset=0.0,
+        spectral_flatness=0.12,
+        low_frequency_ratio=0.03,
+        analyzed_fraction=1.0,
+    )
+    return replace(base, **overrides)
+
+
+def _write_pcm16(path: Path, samples: np.ndarray, sample_rate: int = 16000, channels: int = 1) -> None:
+    clipped = np.clip(samples, -1.0, 1.0)
+    pcm = (clipped * 32767.0).astype("<i2")
+    with wave.open(str(path), "wb") as output:
+        output.setnchannels(channels)
+        output.setsampwidth(2)
+        output.setframerate(sample_rate)
+        output.writeframes(pcm.tobytes())
+
+
+def test_normalize_preprocessing_mode_preserves_supported_values_and_aliases():
+    assert normalize_preprocessing_mode(" AUTO ") == "auto"
+    assert normalize_preprocessing_mode("disabled") == "off"
+    assert normalize_preprocessing_mode("neural") == "denoise"
+
+
+def test_normalize_preprocessing_mode_rejects_unknown_value():
+    try:
+        normalize_preprocessing_mode("studio-magic")
+    except ValueError as exc:
+        assert "studio-magic" in str(exc)
+    else:
+        raise AssertionError("unknown mode must be rejected")
+
+
+def test_auto_policy_leaves_clean_audio_untouched():
+    decision = AudioPreprocessingPolicy().decide(_metrics(), neural_available=True)
+
+    assert decision.action == "none"
+    assert decision.confidence >= 0.8
+    assert any("clean" in reason.lower() for reason in decision.reasons)
+
+
+def test_auto_policy_normalizes_audio_that_is_only_too_quiet():
+    decision = AudioPreprocessingPolicy().decide(
+        _metrics(rms_dbfs=-37.0, peak_dbfs=-15.0, estimated_snr_db=31.0),
+        neural_available=True,
+    )
+
+    assert decision.action == "normalize"
+    assert decision.use_neural is False
+
+
+def test_auto_policy_does_not_amplify_quiet_audio_with_uncertain_snr():
+    decision = AudioPreprocessingPolicy().decide(
+        _metrics(
+            rms_dbfs=-39.0,
+            estimated_snr_db=12.0,
+            noise_floor_dbfs=-55.0,
+            spectral_flatness=0.02,
+        ),
+        neural_available=True,
+    )
+
+    assert decision.action == "none"
+    assert decision.refused is True
+
+
+def test_auto_policy_uses_light_cleanup_for_moderate_noise():
+    decision = AudioPreprocessingPolicy().decide(
+        _metrics(
+            rms_dbfs=-22.0,
+            noise_floor_dbfs=-34.0,
+            estimated_snr_db=12.0,
+            spectral_flatness=0.46,
+            low_frequency_ratio=0.18,
+        ),
+        neural_available=True,
+    )
+
+    assert decision.action == "light_cleanup"
+    assert decision.use_neural is False
+    assert len(decision.reasons) >= 1
+
+
+def test_auto_policy_uses_neural_denoise_only_for_severe_noise_when_available():
+    decision = AudioPreprocessingPolicy().decide(
+        _metrics(
+            rms_dbfs=-23.0,
+            noise_floor_dbfs=-29.0,
+            estimated_snr_db=6.0,
+            spectral_flatness=0.68,
+        ),
+        neural_available=True,
+    )
+
+    assert decision.action == "neural_denoise"
+    assert decision.use_neural is True
+
+
+def test_auto_policy_falls_back_to_light_cleanup_without_neural_backend():
+    decision = AudioPreprocessingPolicy().decide(
+        _metrics(
+            noise_floor_dbfs=-29.0,
+            estimated_snr_db=6.0,
+            spectral_flatness=0.68,
+        ),
+        neural_available=False,
+    )
+
+    assert decision.action == "light_cleanup"
+    assert decision.fallback is True
+    assert any("unavailable" in reason.lower() for reason in decision.reasons)
+
+
+def test_auto_policy_refuses_processing_when_clipping_is_severe():
+    decision = AudioPreprocessingPolicy().decide(
+        _metrics(clipping_ratio=0.04, peak_dbfs=0.0, estimated_snr_db=8.0),
+        neural_available=True,
+    )
+
+    assert decision.action == "none"
+    assert decision.refused is True
+    assert any("clipping" in reason.lower() for reason in decision.reasons)
+
+
+def test_auto_policy_refuses_processing_when_there_is_almost_no_detected_signal():
+    decision = AudioPreprocessingPolicy().decide(
+        _metrics(rms_dbfs=-70.0, peak_dbfs=-55.0, silence_ratio=0.99, estimated_snr_db=0.0),
+        neural_available=True,
+    )
+
+    assert decision.action == "none"
+    assert decision.refused is True
+
+
+def test_decision_and_metrics_are_json_safe():
+    metrics = _metrics()
+    decision = PreprocessingDecision(
+        action="none",
+        confidence=0.9,
+        reasons=("clean input",),
+        use_neural=False,
+    )
+
+    payload = {"metrics": metrics.to_dict(), "decision": decision.to_dict()}
+    roundtrip = json.loads(json.dumps(payload, ensure_ascii=False))
+
+    assert roundtrip["decision"]["action"] == "none"
+    assert math.isfinite(roundtrip["metrics"]["estimated_snr_db"])
+
+
+def test_analyzer_measures_pcm_wav_without_loading_external_models(tmp_path):
+    sample_rate = 16000
+    t = np.arange(sample_rate * 2, dtype=np.float32) / sample_rate
+    samples = 0.25 * np.sin(2.0 * np.pi * 440.0 * t)
+    path = tmp_path / "tone.wav"
+    _write_pcm16(path, samples, sample_rate=sample_rate)
+
+    metrics = AudioQualityAnalyzer().analyze(str(path))
+
+    assert metrics.sample_rate == sample_rate
+    assert metrics.channels == 1
+    assert 1.99 <= metrics.duration_seconds <= 2.01
+    assert -17.0 < metrics.rms_dbfs < -13.0
+    assert metrics.clipping_ratio == 0.0
+    assert metrics.analyzed_fraction == 1.0
+
+
+def test_analyzer_detects_silence_and_clipping(tmp_path):
+    sample_rate = 16000
+    silence = np.zeros(sample_rate, dtype=np.float32)
+    clipped = np.ones(sample_rate, dtype=np.float32)
+    path = tmp_path / "damaged.wav"
+    _write_pcm16(path, np.concatenate([silence, clipped]), sample_rate=sample_rate)
+
+    metrics = AudioQualityAnalyzer().analyze(str(path))
+
+    assert 0.45 <= metrics.silence_ratio <= 0.55
+    assert 0.45 <= metrics.clipping_ratio <= 0.55
+
+
+def test_analyzer_rejects_empty_or_unsupported_audio(tmp_path):
+    path = tmp_path / "empty.wav"
+    path.write_bytes(b"")
+
+    try:
+        AudioQualityAnalyzer().analyze(str(path))
+    except ValueError as exc:
+        assert "audio" in str(exc).lower() or "wav" in str(exc).lower()
+    else:
+        raise AssertionError("empty input must be rejected")
+
+
+class _FakeAnalyzer:
+    def __init__(
+        self,
+        metrics: AudioQualityMetrics,
+        processed_metrics: AudioQualityMetrics | None = None,
+    ):
+        self.metrics = metrics
+        self.processed_metrics = processed_metrics or metrics
+        self.calls: list[str] = []
+
+    def analyze(self, path: str) -> AudioQualityMetrics:
+        self.calls.append(path)
+        return self.metrics if len(self.calls) == 1 else self.processed_metrics
+
+
+class _FakeDspBackend:
+    def __init__(self, output: str | None):
+        self.output = output
+        self.calls: list[tuple[str, str, str]] = []
+
+    def process(self, input_path: str, output_dir: str, action: str) -> str | None:
+        self.calls.append((input_path, output_dir, action))
+        return self.output
+
+
+class _FakeNeuralBackend:
+    def __init__(self, *, available: bool, output: str | None):
+        self.available = available
+        self.output = output
+        self.calls: list[tuple[str, str]] = []
+
+    def is_available(self) -> bool:
+        return self.available
+
+    def process(self, input_path: str, output_dir: str) -> str | None:
+        self.calls.append((input_path, output_dir))
+        return self.output
+
+
+def test_preprocessor_off_preserves_legacy_track_without_analysis(tmp_path):
+    analyzer = _FakeAnalyzer(_metrics())
+    dsp = _FakeDspBackend(str(tmp_path / "unused.wav"))
+    preprocessor = AudioPreprocessor(analyzer=analyzer, dsp_backend=dsp)
+
+    result = preprocessor.prepare("canonical.wav", str(tmp_path), mode="off")
+
+    assert result.asr_path == "canonical.wav"
+    assert result.diarization_path == "canonical.wav"
+    assert result.temporary_paths == ()
+    assert result.report.decision.action == "none"
+    assert analyzer.calls == []
+    assert dsp.calls == []
+
+
+def test_preprocessor_auto_routes_only_asr_through_selected_cleanup(tmp_path):
+    enhanced = str(tmp_path / "enhanced.wav")
+    source_metrics = _metrics(estimated_snr_db=12.0, spectral_flatness=0.46)
+    improved_metrics = _metrics(
+        estimated_snr_db=25.0,
+        noise_floor_dbfs=-45.0,
+        spectral_flatness=0.12,
+    )
+    analyzer = _FakeAnalyzer(source_metrics, improved_metrics)
+    dsp = _FakeDspBackend(enhanced)
+    preprocessor = AudioPreprocessor(analyzer=analyzer, dsp_backend=dsp)
+
+    result = preprocessor.prepare("canonical.wav", str(tmp_path), mode="auto")
+
+    assert result.asr_path == enhanced
+    assert result.diarization_path == "canonical.wav"
+    assert result.temporary_paths == (enhanced,)
+    assert result.report.decision.action == "light_cleanup"
+    assert result.report.processed_metrics == improved_metrics
+    assert dsp.calls == [("canonical.wav", str(tmp_path), "light_cleanup")]
+
+
+def test_preprocessor_auto_keeps_clean_audio_as_single_track(tmp_path):
+    preprocessor = AudioPreprocessor(
+        analyzer=_FakeAnalyzer(_metrics()),
+        dsp_backend=_FakeDspBackend(str(tmp_path / "unused.wav")),
+    )
+
+    result = preprocessor.prepare("canonical.wav", str(tmp_path), mode="auto")
+
+    assert result.asr_path == result.diarization_path == "canonical.wav"
+    assert result.temporary_paths == ()
+    assert result.report.applied is False
+
+
+def test_preprocessor_uses_neural_backend_for_severe_noise(tmp_path):
+    enhanced = str(tmp_path / "neural.wav")
+    neural = _FakeNeuralBackend(available=True, output=enhanced)
+    preprocessor = AudioPreprocessor(
+        analyzer=_FakeAnalyzer(
+            _metrics(estimated_snr_db=5.0, spectral_flatness=0.7),
+            _metrics(
+                estimated_snr_db=26.0,
+                noise_floor_dbfs=-46.0,
+                spectral_flatness=0.08,
+            ),
+        ),
+        dsp_backend=_FakeDspBackend(None),
+        neural_backend=neural,
+    )
+
+    result = preprocessor.prepare("canonical.wav", str(tmp_path), mode="auto")
+
+    assert result.asr_path == enhanced
+    assert result.diarization_path == "canonical.wav"
+    assert result.report.decision.use_neural is True
+    assert neural.calls == [("canonical.wav", str(tmp_path))]
+
+
+def test_preprocessor_falls_back_to_canonical_when_processing_fails(tmp_path):
+    preprocessor = AudioPreprocessor(
+        analyzer=_FakeAnalyzer(_metrics(estimated_snr_db=12.0, spectral_flatness=0.46)),
+        dsp_backend=_FakeDspBackend(None),
+    )
+
+    result = preprocessor.prepare("canonical.wav", str(tmp_path), mode="auto")
+
+    assert result.asr_path == result.diarization_path == "canonical.wav"
+    assert result.report.applied is False
+    assert result.report.runtime_fallback is True
+    assert result.temporary_paths == ()
+
+
+def test_preprocessor_quality_gate_rejects_candidate_that_damages_speech(tmp_path):
+    damaged_path = tmp_path / "damaged.wav"
+    damaged_path.write_bytes(b"candidate")
+    source_metrics = _metrics(estimated_snr_db=12.0, spectral_flatness=0.46)
+    damaged_metrics = _metrics(
+        estimated_snr_db=4.0,
+        spectral_flatness=0.70,
+        clipping_ratio=0.08,
+        silence_ratio=0.75,
+    )
+    preprocessor = AudioPreprocessor(
+        analyzer=_FakeAnalyzer(source_metrics, damaged_metrics),
+        dsp_backend=_FakeDspBackend(str(damaged_path)),
+    )
+
+    result = preprocessor.prepare("canonical.wav", str(tmp_path), mode="auto")
+
+    assert result.asr_path == result.diarization_path == "canonical.wav"
+    assert result.report.applied is False
+    assert result.report.runtime_fallback is True
+    assert "quality gate" in (result.report.fallback_reason or "").lower()
+    assert result.report.processed_metrics == damaged_metrics
+    assert not damaged_path.exists()
+
+
+def test_ffmpeg_backend_uses_argument_list_and_preserves_timeline(monkeypatch, tmp_path):
+    source = tmp_path / "canonical.wav"
+    _write_pcm16(source, np.zeros(16000, dtype=np.float32))
+    captured: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        shutil.copyfile(source, command[-1])
+        return type("Result", (), {"returncode": 0, "stderr": ""})()
+
+    monkeypatch.setattr("src.utils.audio_preprocessing._find_ffmpeg", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr("src.utils.audio_preprocessing.subprocess.run", fake_run)
+
+    backend = FFmpegAudioPreprocessingBackend(logger=lambda _message: None)
+    output = backend.process(str(source), str(tmp_path), "light_cleanup")
+
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert command[0] == "/usr/bin/ffmpeg"
+    assert "-af" in command
+    assert "afftdn" in command[command.index("-af") + 1]
+    assert captured["kwargs"].get("shell") is None
+    assert output is not None
+    assert Path(output).exists()
+
+
+def test_ffmpeg_backend_rejects_duration_drift_and_removes_output(monkeypatch, tmp_path):
+    source = tmp_path / "canonical.wav"
+    _write_pcm16(source, np.zeros(16000, dtype=np.float32))
+    created: list[Path] = []
+
+    def fake_run(command, **_kwargs):
+        target = Path(command[-1])
+        created.append(target)
+        _write_pcm16(target, np.zeros(8000, dtype=np.float32))
+        return type("Result", (), {"returncode": 0, "stderr": ""})()
+
+    monkeypatch.setattr("src.utils.audio_preprocessing._find_ffmpeg", lambda: "ffmpeg")
+    monkeypatch.setattr("src.utils.audio_preprocessing.subprocess.run", fake_run)
+
+    output = FFmpegAudioPreprocessingBackend(logger=lambda _message: None).process(
+        str(source), str(tmp_path), "normalize"
+    )
+
+    assert output is None
+    assert created and not created[0].exists()

--- a/tests/test_cli_backend.py
+++ b/tests/test_cli_backend.py
@@ -79,6 +79,17 @@ def test_cli_sortformer_does_not_require_hf_token(tmp_path, monkeypatch):
     assert capture["process_kwargs"]["diarization_backend"] == "sortformer"
 
 
+def test_cli_forwards_audio_preprocessing_mode(tmp_path, monkeypatch):
+    result, capture, _ = _run_cli_with_fake_loader(
+        tmp_path,
+        monkeypatch,
+        ["--audio-preprocessing", "off"],
+    )
+
+    assert result.exit_code == 0
+    assert capture["process_kwargs"]["audio_preprocessing_mode"] == "off"
+
+
 def test_cli_sortformer_rejects_fixed_speaker_count(tmp_path, monkeypatch):
     monkeypatch.delenv("HF_TOKEN", raising=False)
     result, _capture, _ = _run_cli_with_fake_loader(

--- a/tests/test_cli_progress.py
+++ b/tests/test_cli_progress.py
@@ -36,10 +36,12 @@ class FakeProcessor:
         estimated_transcription_ratio=0.95,
         enable_diarization=False,
         diarization_backend="pyannote",
+        audio_preprocessing_mode="auto",
         num_speakers=None,
         output_formats=None,
     ):
         assert diarization_backend == "pyannote"
+        assert audio_preprocessing_mode == "auto"
         if self.progress_callback:
             self.progress_callback(ProgressEvent(
                 stage="transcription",

--- a/tests/test_deepfilter_backend.py
+++ b/tests/test_deepfilter_backend.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+import numpy as np
+
+from src.utils.deepfilter_backend import (
+    DeepFilterAsset,
+    DeepFilterBinaryManager,
+    DeepFilterNetBinaryBackend,
+    _asset_for,
+)
+from tests.test_audio_preprocessing import _write_pcm16
+
+
+def test_asset_selection_covers_supported_release_targets():
+    assert _asset_for("linux", "x86_64").filename.endswith("linux-musl")
+    assert _asset_for("linux", "arm64").filename.endswith("linux-gnu")
+    assert _asset_for("darwin", "arm64").filename.endswith("apple-darwin")
+    assert _asset_for("win32", "AMD64").filename.endswith("windows-msvc.exe")
+    assert _asset_for("win32", "arm64") is None
+
+
+def test_binary_manager_downloads_atomically_and_verifies_checksum(monkeypatch, tmp_path):
+    payload = b"verified-deepfilter-binary"
+    asset = DeepFilterAsset("test-binary", hashlib.sha256(payload).hexdigest())
+    manager = DeepFilterBinaryManager(cache_dir=tmp_path, asset=asset)
+    downloads: list[str] = []
+
+    def fake_download(url: str, target: Path):
+        downloads.append(url)
+        target.write_bytes(payload)
+
+    monkeypatch.setattr(manager, "_download", fake_download)
+
+    first = Path(manager.ensure())
+    second = Path(manager.ensure())
+
+    assert first == second
+    assert first.read_bytes() == payload
+    assert len(downloads) == 1
+    assert not list(tmp_path.glob("*.download"))
+
+
+def test_binary_manager_replaces_symlink_in_executable_cache(monkeypatch, tmp_path):
+    payload = b"verified-deepfilter-binary"
+    asset = DeepFilterAsset("test-binary", hashlib.sha256(payload).hexdigest())
+    outside = tmp_path / "outside"
+    outside.write_bytes(payload)
+    target = tmp_path / asset.filename
+    try:
+        target.symlink_to(outside)
+    except OSError:
+        return  # Windows CI can deny unprivileged symlink creation.
+    manager = DeepFilterBinaryManager(cache_dir=tmp_path, asset=asset)
+    monkeypatch.setattr(manager, "_download", lambda _url, path: path.write_bytes(payload))
+
+    installed = Path(manager.ensure())
+
+    assert installed == target
+    assert not installed.is_symlink()
+    assert installed.read_bytes() == payload
+    assert outside.read_bytes() == payload
+
+
+def test_binary_manager_rejects_checksum_mismatch(monkeypatch, tmp_path):
+    asset = DeepFilterAsset("test-binary", hashlib.sha256(b"expected").hexdigest())
+    manager = DeepFilterBinaryManager(cache_dir=tmp_path, asset=asset)
+    monkeypatch.setattr(manager, "_download", lambda _url, target: target.write_bytes(b"tampered"))
+
+    try:
+        manager.ensure()
+    except RuntimeError as exc:
+        assert "checksum" in str(exc).lower()
+    else:
+        raise AssertionError("checksum mismatch must fail closed")
+
+    assert not (tmp_path / asset.filename).exists()
+    assert not list(tmp_path.glob("*.download"))
+
+
+def test_binary_manager_honors_executable_cache_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("GIGAAM_DEEPFILTER_DIR", str(tmp_path))
+    manager = DeepFilterBinaryManager(asset=DeepFilterAsset("binary", "0" * 64))
+
+    assert manager.cache_dir == tmp_path
+
+
+def test_binary_manager_rejects_untrusted_download_url(tmp_path):
+    target = tmp_path / "download"
+
+    try:
+        DeepFilterBinaryManager._download("http://example.com/binary", target)
+    except RuntimeError as exc:
+        assert "trusted GitHub HTTPS" in str(exc)
+    else:
+        raise AssertionError("untrusted download URL must fail closed")
+
+    assert not target.exists()
+
+
+class _FakeManager:
+    def supported(self):
+        return True
+
+    def ensure(self):
+        return "/opt/deep-filter"
+
+
+def test_binary_backend_cleans_workspace_when_nested_directory_creation_fails(
+    monkeypatch,
+    tmp_path,
+):
+    canonical = tmp_path / "canonical.wav"
+    _write_pcm16(canonical, np.zeros(16000, dtype=np.float32))
+    backend = DeepFilterNetBinaryBackend(manager=_FakeManager(), logger=lambda _message: None)
+    original_mkdir = Path.mkdir
+    calls = 0
+
+    def fail_second_nested_mkdir(path, *args, **kwargs):
+        nonlocal calls
+        if path.name in {"input", "enhanced"}:
+            calls += 1
+            if calls == 2:
+                raise OSError("simulated filesystem failure")
+        return original_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", fail_second_nested_mkdir)
+
+    assert backend.process(str(canonical), str(tmp_path)) is None
+    assert not list(tmp_path.glob("gigaam_deepfilter_*"))
+
+
+def test_binary_backend_timeout_falls_back_and_cleans_workspace(monkeypatch, tmp_path):
+    canonical = tmp_path / "canonical.wav"
+    _write_pcm16(canonical, np.zeros(16000, dtype=np.float32))
+    backend = DeepFilterNetBinaryBackend(manager=_FakeManager(), logger=lambda _message: None)
+    monkeypatch.setattr(
+        backend,
+        "_run",
+        lambda command, *, timeout: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(command, timeout)
+        ),
+    )
+    monkeypatch.setattr("src.utils.deepfilter_backend._find_ffmpeg", lambda: "ffmpeg")
+
+    assert backend.process(str(canonical), str(tmp_path)) is None
+    assert not list(tmp_path.glob("gigaam_deepfilter_*"))
+    assert not list(tmp_path.glob("temp_deepfiltered_*.wav"))
+
+
+def test_binary_backend_compensates_timeline_and_cleans_workspace(monkeypatch, tmp_path):
+    canonical = tmp_path / "canonical.wav"
+    _write_pcm16(canonical, np.zeros(16000, dtype=np.float32))
+    backend = DeepFilterNetBinaryBackend(
+        manager=_FakeManager(),
+        logger=lambda _message: None,
+    )
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], *, timeout: float):
+        commands.append(command)
+        if command[0] == "/opt/deep-filter":
+            output_dir = Path(command[command.index("--output-dir") + 1])
+            _write_pcm16(output_dir / "audio.wav", np.zeros(48000 - 1440, dtype=np.float32), 48000)
+        elif "48000" in command:
+            _write_pcm16(Path(command[-1]), np.zeros(48000, dtype=np.float32), 48000)
+        else:
+            _write_pcm16(Path(command[-1]), np.zeros(16000, dtype=np.float32), 16000)
+        return type("Result", (), {"returncode": 0, "stderr": ""})()
+
+    monkeypatch.setattr(backend, "_run", fake_run)
+    monkeypatch.setattr("src.utils.deepfilter_backend._find_ffmpeg", lambda: "ffmpeg")
+
+    output = backend.process(str(canonical), str(tmp_path))
+
+    assert output is not None
+    assert Path(output).exists()
+    assert len(commands) == 3
+    assert commands[1][0] == "/opt/deep-filter"
+    assert "-D" in commands[1]
+    assert "apad,atrim=duration=1.000000000" in commands[2]
+    assert not list(tmp_path.glob("gigaam_deepfilter_*"))

--- a/tests/test_processor_audio_preprocessing.py
+++ b/tests/test_processor_audio_preprocessing.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from src.core.processor import TranscriptionProcessor
+from src.utils.audio_preprocessing import (
+    AudioPreprocessingReport,
+    AudioQualityMetrics,
+    PreprocessedAudio,
+    PreprocessingDecision,
+)
+
+
+class _ModelLoader:
+    def __init__(self):
+        self.paths: list[str] = []
+
+    def transcribe_longform(self, path, progress_callback=None):
+        self.paths.append(path)
+        if progress_callback:
+            progress_callback(1.0, 1.0, 1.0)
+        return [{"transcription": "тест", "boundaries": (0.0, 1.0)}]
+
+
+class _Stats:
+    pass
+
+
+class _Converter:
+    def __init__(self, canonical_path: str):
+        self.canonical_path = canonical_path
+
+    def convert_to_wav(self, *_args, progress_callback=None, **_kwargs):
+        if progress_callback:
+            progress_callback(1.0)
+        return self.canonical_path
+
+
+class _Preprocessor:
+    def __init__(self, prepared: PreprocessedAudio):
+        self.prepared = prepared
+        self.calls: list[tuple[str, str, str]] = []
+
+    def prepare(self, canonical_path: str, output_dir: str, *, mode: str):
+        self.calls.append((canonical_path, output_dir, mode))
+        return self.prepared
+
+
+def _metrics() -> AudioQualityMetrics:
+    return AudioQualityMetrics(
+        duration_seconds=1.0,
+        sample_rate=16000,
+        channels=1,
+        rms_dbfs=-20.0,
+        peak_dbfs=-3.0,
+        noise_floor_dbfs=-34.0,
+        estimated_snr_db=12.0,
+        clipping_ratio=0.0,
+        silence_ratio=0.1,
+        dc_offset=0.0,
+        spectral_flatness=0.5,
+        low_frequency_ratio=0.03,
+        analyzed_fraction=1.0,
+    )
+
+
+def _prepared(asr_path: str, diarization_path: str) -> PreprocessedAudio:
+    decision = PreprocessingDecision(
+        action="light_cleanup",
+        confidence=0.8,
+        reasons=("moderate noise",),
+        use_neural=False,
+    )
+    report = AudioPreprocessingReport(
+        mode="auto",
+        metrics=_metrics(),
+        decision=decision,
+        applied=True,
+        backend="ffmpeg",
+        elapsed_seconds=0.1,
+    )
+    return PreprocessedAudio(
+        asr_path=asr_path,
+        diarization_path=diarization_path,
+        temporary_paths=(asr_path,),
+        report=report,
+    )
+
+
+def test_processor_routes_enhanced_audio_to_asr_and_canonical_to_diarization(monkeypatch, tmp_path):
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"source")
+    canonical = tmp_path / "canonical.wav"
+    canonical.write_bytes(b"canonical")
+    enhanced = tmp_path / "enhanced.wav"
+    enhanced.write_bytes(b"enhanced")
+
+    model = _ModelLoader()
+    processor = TranscriptionProcessor(model, _Stats(), logger=lambda _message: None)
+    processor.audio_converter = _Converter(str(canonical))
+    fake_preprocessor = _Preprocessor(_prepared(str(enhanced), str(canonical)))
+    processor.audio_preprocessor = fake_preprocessor
+    diarization_paths: list[str] = []
+
+    def fake_diarization(audio_path, utterances, **_kwargs):
+        diarization_paths.append(audio_path)
+        return [{**utterances[0], "speaker": "SPEAKER_00"}]
+
+    monkeypatch.setattr(processor, "_apply_diarization", fake_diarization)
+    monkeypatch.setattr("src.core.processor.AudioConverter.get_media_duration", lambda _path: 1.0)
+
+    result = processor.process_file(
+        str(source),
+        str(tmp_path),
+        0,
+        1,
+        enable_diarization=True,
+        diarization_backend="sortformer",
+        audio_preprocessing_mode="auto",
+    )
+
+    assert result["success"] is True
+    assert model.paths == [str(enhanced)]
+    assert diarization_paths == [str(canonical)]
+    assert fake_preprocessor.calls == [(str(canonical), str(tmp_path), "auto")]
+    assert result["audio_preprocessing"]["decision"]["action"] == "light_cleanup"
+    assert not canonical.exists()
+    assert not enhanced.exists()
+
+
+def test_processor_default_mode_remains_off_and_backward_compatible(monkeypatch, tmp_path):
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    canonical = tmp_path / "canonical.wav"
+    canonical.write_bytes(b"canonical")
+
+    model = _ModelLoader()
+    processor = TranscriptionProcessor(model, _Stats(), logger=lambda _message: None)
+    processor.audio_converter = _Converter(str(canonical))
+    decision = PreprocessingDecision(
+        action="none",
+        confidence=1.0,
+        reasons=("disabled",),
+        use_neural=False,
+    )
+    report = AudioPreprocessingReport(
+        mode="off",
+        metrics=None,
+        decision=decision,
+        applied=False,
+    )
+    fake_preprocessor = _Preprocessor(
+        PreprocessedAudio(str(canonical), str(canonical), (), report)
+    )
+    processor.audio_preprocessor = fake_preprocessor
+    monkeypatch.setattr("src.core.processor.AudioConverter.get_media_duration", lambda _path: 1.0)
+
+    result = processor.process_file(str(source), str(tmp_path), 0, 1)
+
+    assert result["success"] is True
+    assert model.paths == [str(canonical)]
+    assert fake_preprocessor.calls == [(str(canonical), str(tmp_path), "off")]
+    assert result["audio_preprocessing"]["mode"] == "off"
+    assert not canonical.exists()

--- a/tests/test_processor_progress.py
+++ b/tests/test_processor_progress.py
@@ -120,7 +120,8 @@ def test_processor_progress_without_diarization(monkeypatch, tmp_path):
     assert "export" in [ev.stage for ev in events]
     assert "finalizing" == events[-1].stage
     assert events[-1].file_progress == 1.0
-    assert _collect_stage_progress(events, "conversion")[-1] == 0.15
+    assert _collect_stage_progress(events, "conversion")[-1] == 0.12
+    assert _collect_stage_progress(events, "preprocessing")[-1] == 0.15
     assert _collect_stage_progress(events, "transcription")[-1] >= 0.95
     assert _collect_stage_progress(events, "finalizing")[-1] == 1.0
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -56,14 +56,16 @@ def test_progress_plan_maps_stage_bands_without_diarization():
     plan = ProgressPlan(has_diarization=False)
     assert plan.map_stage_to_file_progress("preparing", 0.0) == 0.0
     assert plan.map_stage_to_file_progress("preparing", 1.0) == 0.02
-    assert plan.map_stage_to_file_progress("conversion", 1.0) == 0.15
+    assert plan.map_stage_to_file_progress("conversion", 1.0) == 0.12
+    assert plan.map_stage_to_file_progress("preprocessing", 1.0) == 0.15
     assert plan.map_stage_to_file_progress("transcription", 0.0) == 0.15
     assert plan.map_stage_to_file_progress("transcription", 1.0) == 0.95
 
 
 def test_progress_plan_maps_stage_bands_with_diarization():
     plan = ProgressPlan(has_diarization=True)
-    assert plan.map_stage_to_file_progress("conversion", 1.0) == 0.12
+    assert plan.map_stage_to_file_progress("conversion", 1.0) == 0.10
+    assert plan.map_stage_to_file_progress("preprocessing", 1.0) == 0.12
     assert plan.map_stage_to_file_progress("transcription", 1.0) == 0.7
     assert plan.map_stage_to_file_progress("diarization", 1.0) == 0.95
 

--- a/web/web_app.py
+++ b/web/web_app.py
@@ -39,7 +39,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from starlette.middleware.sessions import SessionMiddleware
 
-from src.config import HF_TOKEN, MEDIA_EXTENSIONS, OUTPUT_FORMATS
+from src.config import AUDIO_PREPROCESSING_MODE, HF_TOKEN, MEDIA_EXTENSIONS, OUTPUT_FORMATS
 from src.core.model_loader import ModelLoader
 from src.services import file_policy, llm_service, task_store, transcription_service
 from src.services import health as health_service
@@ -554,6 +554,7 @@ async def process_transcription(
                 stage_names = {
                     'preparing': 'Подготовка...',
                     'conversion': 'Конвертация...',
+                    'preprocessing': 'Анализ и подготовка аудио...',
                     'transcription': 'Распознавание речи...',
                     'diarization': 'Диаризация...',
                     'export': 'Экспорт...',
@@ -589,6 +590,7 @@ async def process_transcription(
                     output_formats=output_formats if output_formats else ['txt', 'txt_timecodes'],
                     enable_diarization=enable_diarization,
                     diarization_backend=diarization_backend,
+                    audio_preprocessing_mode=AUDIO_PREPROCESSING_MODE,
                     num_speakers=num_speakers,
                 ),
             )
@@ -632,6 +634,7 @@ async def process_transcription(
                 'result_files': result_files,
                 'processing_time': result['total_time'],
                 'media_duration': result.get('media_duration', 0),
+                'audio_preprocessing': result.get('audio_preprocessing'),
             })
             _persist_tasks_index()
             _task_log(task_id, f"Обработка завершена за {time_formatter.format_duration(result['total_time'])}")
@@ -657,6 +660,8 @@ async def process_transcription(
                     'user': tasks_storage[task_id].get('user'),
                     'processing_time': result['total_time'],
                     'media_duration': result.get('media_duration', 0),
+                    'audio_preprocessing_mode': AUDIO_PREPROCESSING_MODE,
+                    'audio_preprocessing': result.get('audio_preprocessing'),
                 })
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

Adds a conservative, explainable audio preprocessing subsystem before ASR.

- diagnoses canonical WAV quality without loading long recordings fully into memory;
- chooses pass-through, bounded gain, light FFmpeg cleanup, or optional DeepFilterNet;
- re-analyzes every candidate and falls back when measurable benefit is absent or speech may be damaged;
- preserves sample count/timeline and never trims silence;
- sends enhanced audio only to ASR while diarization keeps the aligned canonical track;
- records a structured diagnostics/decision/fallback report;
- adds preprocessing progress and propagation through Desktop, CLI, REST API, Web, and TUI worker;
- downloads the pinned official DeepFilterNet 0.5.6 binary on demand with HTTPS allowlisting, redirect checks, size limit, atomic install, and SHA-256 verification;
- keeps the neural backend optional and adds no Python ML dependency.

## Modes

- `off`: legacy behavior;
- `auto`: conservative diagnosis and minimum necessary processing (surface default);
- `light`: request FFmpeg cleanup, still subject to safety refusal and post-check;
- `denoise`: request neural denoise, with FFmpeg/canonical fallback.

`TranscriptionProcessor.process_file()` itself keeps `off` as its additive argument default for backward compatibility. User-facing surfaces pass `AUDIO_PREPROCESSING_MODE`, whose default is `auto`.

## Timeline and safety invariants

- no silence removal, trimming, time stretch, source separation, or dereverberation;
- FFmpeg candidate drift tolerance is two 16 kHz samples;
- DeepFilterNet delay is compensated and output is padded/trimmed at the tail to canonical duration;
- enhanced candidates are rejected on increased clipping, excessive new silence, useful-level collapse, or absent measurable benefit;
- cleanup removes only files owned by the current processor run;
- unsupported platform, offline download, checksum mismatch, timeout, inference failure, or analyzer failure cannot abort baseline transcription.

## Verification

- Python: **350 tests passed** (`QT_QPA_PLATFORM=offscreen pytest -q -ra`)
- Rust TUI: **11 tests passed** in `rust:1.88-slim`
- Ruff: clean
- Bandit on new preprocessing modules: clean after reviewing argument-list subprocess calls (`shell=False`)
- Docker Compose config: valid
- `compileall` and `git diff --check`: clean
- static added-line secret/injection scan: clean

### Real execution

1. Official Linux x64 DeepFilterNet 0.5.6 binary executed successfully on noisy 48 kHz audio. Final 16 kHz output preserved exact duration; spectral flatness improved from `0.215246` to `0.012296`; quality gate accepted it. A separate four-marker alignment smoke measured **0 samples / 0.0 ms lag** with normalized correlation `0.93736` and exact `64,000 / 64,000` frames.
2. Real FFmpeg cleanup preserved `96,000 / 96,000` frames on a six-second noisy case.
3. Three Apache-2.0 Russian VoxForge samples were processed end to end through conversion, diagnosis, policy, FFmpeg and post-check. All preserved exact frame counts:
   - `mikr.wav`: normalize; estimated SNR `35.75 → 35.72 dB`;
   - `ru_test.wav`: light cleanup; `17.90 → 25.84 dB`;
   - `test.wav`: light cleanup; `28.00 → 31.99 dB`.

All downloaded test binaries, audio, model artifacts, Rust image/build output, and temporary caches are removed before shipping.

## Security/dependency note

The feature adds no Python dependency. A repository-level `pip-audit -r requirements.txt --no-deps` reports pre-existing advisories in pinned dependencies (including ONNX, aiohttp, Pillow, transformers and yt-dlp); this PR does not change those pins and does not add to that baseline.

## Known limitation / why draft

This validates signal metrics, exact timeline behavior, Russian real-audio routing, and actual backend execution. It does **not** yet establish corpus-level GigaAM WER/CER or pyannote/Sortformer DER improvement. Auto remains conservative and has a post-check/fallback, but the policy thresholds should receive a separate versioned calibration pass on a labeled Russian corpus before this is promoted from draft. Multichannel pre-downmix diagnostics, dereverberation, RNNoise, and source separation are deliberately excluded from auto until downstream benchmarks justify them.
